### PR TITLE
Use codegen to generate string literals.

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -4,6 +4,7 @@
  */
 const loaderUtils = require("loader-utils");
 const esprima = require('esprima');
+const escodegen = require('escodegen');
 const esUtils = require('esprima-ast-utils');
 const chalk = require('chalk');
 const Promise = require('bluebird');
@@ -117,7 +118,7 @@ module.exports = function (content, map) {
                         if (typeof req === 'undefined') {
                             console.log(chalk.red('Converting require: ') + className + ' => ' + req);
                         }
-                        reqStr += 'require(\'' + req + '\');\r\n';
+                        reqStr += 'require(' + escodegen.generate({ type: 'Literal', value: req}) + ');\r\n';
                     });
                     return reqStr;
                 }
@@ -169,10 +170,10 @@ module.exports = function (content, map) {
                         let result = ExtParser.query(require);
                         if (result instanceof Array) {
                             result.forEach((require) => {
-                                requireStr += `require('${require.src}');`
+                                requireStr += `require(${escodegen.generate({ type: 'Literal', value: require.src})});`
                             });
                         } else {
-                            requireStr += `require('${ExtParser.query(require).src}');`
+                            requireStr += `require(${escodegen.generate({ type: 'Literal', value: ExtParser.query(require).src})});`
                         }
 
                     })
@@ -232,7 +233,7 @@ module.exports = function (content, map) {
              * Some
              */
             content = content.replace(/Ext.safeCreate\(['"](.*)['"]/img, function (match, offset, string) {
-                return 'require(\'' + resolveClassFile(offset) + '\');\r\n' + match;
+                return 'require(' + escodegen.generate({ type: 'Literal', value: resolveClassFile(offset)}) + ');\r\n' + match;
             });
 
             callback(null, content, map);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "chalk": "^1.1.3",
+    "escodegen": "^1.9.0",
     "esprima": "^3.1.3",
     "esprima-ast-utils": "0.0.6",
     "loader-utils": "^1.1.0",


### PR DESCRIPTION
Paths may contain characters that should be escaped in javascript strings.
The most common example is backslash which is used as path separator for Windows.

Using proper code generator ensures that such characters are correctly represented in generated code.