### PR TITLE
Extjs7 related changes

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -175,7 +175,6 @@ module.exports = function (content, map) {
 
                 var ctor = new use(objVal.options);
                 pathMap[map].use = ctor;
-                debugger;
                 return ctor.ready().then(function (list) {
                     let config = pathMap[map];
                     pathMap[map] = ctor;

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -12,7 +12,11 @@ const crypto = require("crypto");
 const fs = require('fs');
 
 const cacheDir = './.cache';
-
+try {
+    fs.statSync(cacheDir);
+} catch (e) {
+    fs.mkdirSync(cacheDir);
+}
 module.exports.raw = true;
 
 module.exports = function (content, map) {
@@ -50,11 +54,16 @@ module.exports = function (content, map) {
                             classes = pathMap[prefix].query(className);
                             if (classes instanceof Array) {
                                 retVal = classes.map((className) => {
-                                    return className.src
+                                    return className.src;
                                 });
                             } else {
                                 try {
-                                    retVal = [classes.src, ...classes.overrides];
+                                    if (!classes.src) {
+                                        console.log(chalk.red(`Required class "${className}" not found in ${self.resourcePath}`));
+                                        retVal = [];
+                                    } else {
+                                        retVal = [classes.src];
+                                    }
                                 } catch (e) {
                                     console.log(prefix, className);
                                 }
@@ -67,18 +76,12 @@ module.exports = function (content, map) {
                 }
             }
         }
-        return [...retVal];
+        return [...retVal].filter(Boolean);
 
     }
 
 
     try {
-
-        try {
-            fs.statSync(cacheDir);
-        } catch (e) {
-            fs.mkdirSync(cacheDir);
-        }
         /**
          * Process each possible ways how required files can be referenced in Ext.js
          * The regexp's below are dealing with the following cases:
@@ -147,18 +150,17 @@ module.exports = function (content, map) {
         }
 
         const contentDigest = sha1(content);
-        const cacheFile = cacheDir + '/' + contentDigest;
+        const cacheFile = cacheDir + '/content_' + contentDigest;
         let tree;
 
         if (fs.existsSync(cacheFile)) {
-            tree = JSON.parse(fs.readFileSync(cacheFile, { encoding: 'utf-8' }));
-        } else {
-            tree = esprima.parse(content, {
-                range: true
-            });
-            fs.writeFileSync(cacheFile, JSON.stringify(tree));
+            const cachedContent = fs.readFileSync(cacheFile, { encoding: 'utf-8' });
+            callback(null, cachedContent, map);
+            return;
         }
-
+        tree = esprima.parse(content, {
+            range: true
+        });
 
         Promise.each(Object.keys(pathMap), function (map) {
             var objVal = pathMap[map];
@@ -173,19 +175,21 @@ module.exports = function (content, map) {
 
                 var ctor = new use(objVal.options);
                 pathMap[map].use = ctor;
+                debugger;
                 return ctor.ready().then(function (list) {
                     let config = pathMap[map];
                     pathMap[map] = ctor;
                     if (Array.isArray(config.options.aliasForNs)) {
                         config.options.aliasForNs.forEach(ns => {
                             pathMap[ns] = ctor;
-                        })
+                        });
                     }
                     return Promise.resolve();
-                })
+                });
             }
         }).then(() => {
             let ExtParser = pathMap['Ext'];
+            let noParse = false;
             if (ExtParser.query) {
                 let fileProps = ExtParser.fileMapCache[self.resourcePath];
                 if (fileProps && fileProps.requires && fileProps.requires.length > 0) {
@@ -194,14 +198,32 @@ module.exports = function (content, map) {
                         let result = ExtParser.query(require);
                         if (result instanceof Array) {
                             result.forEach((require) => {
-                                requireStr += `require('${require.src}');`
+                                requireStr += `require('${require.src}');\n`;
                             });
                         } else {
-                            requireStr += `require('${ExtParser.query(require).src}');`
+                            requireStr += `require('${ExtParser.query(require).src}');\n`;
                         }
 
                     });
                     updates.push({ type: 'add', start: 0, end: 0, data: requireStr });
+                }
+                if (fileProps && fileProps.overrides && fileProps.overrides.length > 0) {
+                    let requireStr = '';
+                    fileProps.overrides.forEach((require) => {
+                        let result = ExtParser.query(require);
+                        if (result instanceof Array) {
+                            result.forEach((require) => {
+                                requireStr += `require('${require.src}');\n`;
+                            });
+                        } else {
+                            const requireSource = ExtParser.query(require).src || require;
+                            if (requireSource) {
+                                requireStr += `require('${requireSource}');\n`;
+                            }
+                        }
+
+                    });
+                    updates.push({ type: 'add', start: content.length, end: content.length, data: requireStr });
                 }
             }
             esUtils.parentize(tree);
@@ -238,10 +260,10 @@ module.exports = function (content, map) {
                             end: parent.range[configMap[nodeName].end ? 1 : 0],
                             data: requireStr
                         });
+                        //   console.log('Requires by loader', requireStr);
                     }
                 }
             });
-
             updates.sort((a, b) => {
                 return b.end - a.end
             }).forEach(updateItem => {
@@ -269,6 +291,8 @@ module.exports = function (content, map) {
                         value: className
                     }) + ');\r\n' + match;
                 });
+
+                fs.writeFileSync(cacheFile, content);
                 callback(null, content, map);
             } catch (e) {
                 callback(e)
@@ -276,7 +300,7 @@ module.exports = function (content, map) {
         });
 
     } catch (e) {
-        console.error(chalk.red('error parsing: ') + e);
+        console.error(chalk.red(`Error parsing ${self.resourcePath}`) + e);
         callback(e);
     }
 

--- a/package.json
+++ b/package.json
@@ -14,11 +14,13 @@
     "loader-utils": "^1.1.0",
     "strip-comments": "^0.4.4"
   },
+  "peerDependencies": {
+    "extjs-parser": "^2"
+  },
   "description": "Ext.js loader module for webpack",
-  "devDependencies": {},
   "directories": {},
   "engines": {
-    "node": ">=0.12.0 || >=4.3.0 <5.0.0 || >=5.10"
+    "node": ">=10"
   },
   "files": [
     "index.js",
@@ -45,5 +47,5 @@
     "url": "git+ssh://git@github.com/zmagyar/extjs-loader.git"
   },
   "scripts": {},
-  "version": "0.0.13"
+  "version": "1.0.0"
 }


### PR DESCRIPTION
Major version as it _may_ breaking. 
Extjs-parser is now peer dependency.
Caching is content based instead of AST.
Overrides added to the overridden classes at the _end_ of the file, instead of adding every time we require a class with overrides.